### PR TITLE
Add api send

### DIFF
--- a/apirelay.go
+++ b/apirelay.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+
+	msgraph "github.com/R2D2Env/go-msgraph"
+	"github.com/chrj/smtpd"
+)
+
+var graphClient msgraph.GraphClient
+
+func InitMSGraph() {
+	// initialize the GraphClient via JSON-Load.
+	// Specify JSON-Fields TenantID, ApplicationID and ClientSecret
+	fileContents, err := ioutil.ReadFile(*apiCredentialFile)
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"apiCredentialFile": *apiCredentialFile,
+		}).WithError(err).Warn("could not read api credentials file")
+	}
+	json.Unmarshal(fileContents, &graphClient)
+}
+
+func GraphRelay(env smtpd.Envelope) {
+	if err := graphClient.SendMailMIME(env.Sender, env.Data); err != nil {
+		log.WithFields(
+			logrus.Fields{
+				"Sender":     env.Sender,
+				"Recipients": env.Recipients,
+				"Body":       string(env.Data),
+			}).WithError(err).Warn("send mail error")
+	}
+}

--- a/config.go
+++ b/config.go
@@ -41,6 +41,8 @@ var (
 	remoteAuthStr     = flag.String("remote_auth", "none", "Auth method on outgoing SMTP server (none, plain, login)")
 	remoteAuth        smtp.Auth
 	remoteSender      = flag.String("remote_sender", "", "Sender e-mail address on outgoing SMTP server")
+	apiService        = flag.String("api_service", "", "API service in use")
+	apiCredentialFile = flag.String("api_credential_file", "", "Credential file used to connect to API-based email service")
 	versionInfo       = flag.Bool("version", false, "Show version information")
 )
 
@@ -173,8 +175,8 @@ func ConfigLoad() {
 	// Set up logging as soon as possible
 	setupLogger()
 
-	if *remoteHost == "" && *command == "" {
-		log.Warn("no remote_host or command set; mail will not be forwarded!")
+	if *remoteHost == "" && *command == "" && *apiService == "" {
+		log.Warn("no remote_host or command or api_service set; mail will not be forwarded!")
 	}
 
 	setupAllowedNetworks()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
-module github.com/decke/smtprelay
+module github.com/R2D2E/smtp-to-http-relay
 
 require (
+	github.com/R2D2Env/go-msgraph v0.0.0-20210608195849-1b75cf549871
 	github.com/chrj/smtpd v0.3.0
 	github.com/google/uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
@@ -8,4 +9,4 @@ require (
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 )
 
-go 1.13
+go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/R2D2Env/go-msgraph v0.0.0-20210608195849-1b75cf549871 h1:TSmMaWoWimuCLMgJ5DAivi+v3T25IPj8aJXaZd0d+Z8=
+github.com/R2D2Env/go-msgraph v0.0.0-20210608195849-1b75cf549871/go.mod h1:dfzD+qQofF6td0s45+mRsXzZirvsns6z50YxAMee6gc=
 github.com/chrj/smtpd v0.3.0 h1:cw1LSHDOz7N3XbkcZSF/bue9dh7ATKk5ZksfBztV6b0=
 github.com/chrj/smtpd v0.3.0/go.mod h1:1hmG9KbrE10JG1SmvG79Krh4F6713oUrw2+gRp1oSYk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/smtprelay.ini
+++ b/smtprelay.ini
@@ -81,3 +81,12 @@
 
 ; Pipe messages to external command
 ;command = /usr/local/bin/script
+
+; Relay messages to HTTP-based email API endpoint
+; Support for: Microsoft Office 365 (through Microsoft Graph API)
+
+; Email API. Currently supported: MicrosoftGraphv1
+;api_service = MicrosoftGraphv1
+
+; Credential File should have fields ApplicationID, ClientSecret, TenantID for Microsoft Graph 
+;api_credential_file = <filepath>.json


### PR DESCRIPTION
Add capability to relay messages to MS Graph API

- Adds config file flags for MS Graph API service & credential files
- Adds calls to r2d2env/go-msgraph when config flags are set to relay incoming messages